### PR TITLE
add tags for web summary and update id for reclaim

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -136,7 +136,8 @@
       "author": "Wootzapp Team",
       "download_url": "https://raw.githubusercontent.com/wootzapp/ext-store/main/web%20summary/AIResearcher.crx",
       "icon_url": "https://raw.githubusercontent.com/wootzapp/ext-store/main/web%20summary/repo/public/icons/icon128.png",
-      "github_url": "https://github.com/wootzapp/ext-store/tree/main/web%20summary/repo","tags": [
+      "github_url": "https://github.com/wootzapp/ext-store/tree/main/web%20summary/repo",
+      "tags": [
         "AI",
         "Research",
         "Summarization",

--- a/extensions.json
+++ b/extensions.json
@@ -136,7 +136,15 @@
       "author": "Wootzapp Team",
       "download_url": "https://raw.githubusercontent.com/wootzapp/ext-store/main/web%20summary/AIResearcher.crx",
       "icon_url": "https://raw.githubusercontent.com/wootzapp/ext-store/main/web%20summary/repo/public/icons/icon128.png",
-      "github_url": "https://github.com/wootzapp/ext-store/tree/main/web%20summary/repo"
+      "github_url": "https://github.com/wootzapp/ext-store/tree/main/web%20summary/repo","tags": [
+        "AI",
+        "Research",
+        "Summarization",
+        "Fact Checking",
+        "Productivity"
+      ],
+      "created_at": "2025-08-11T15:00:00Z",
+      "updated_at": "2025-08-11T15:00:00Z"
     },
     {
       "id": "fkagldhhbbaillkjbjilcgflcihbkmoe",
@@ -269,7 +277,7 @@
       "updated_at": "2025-07-16T15:00:00Z"
     },
     {
-      "id": "bkghjikplaochjjgpoapjagadgponikp",
+      "id": "cpanfhhncafgokableoilhanbkdpafpk",
       "name": "Reclaim",
       "description": "Verify, Not Reveal",
       "version": "1.0.0",


### PR DESCRIPTION
Added missing tags for AI Researcher (web summary) extension and updated the extension ID for Reclaim to match the latest configuration.